### PR TITLE
Added missing library and target java version in pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,18 @@
   <groupId>TG</groupId>
   <artifactId>GraphTheory-JGraphT</artifactId>
   <version>0.0.1-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
   <packaging>jar</packaging>
 
   <name>GraphTheory-JGraphT</name>
@@ -15,6 +27,12 @@
   </properties>
 
   <dependencies>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.6.2</version>
+        <scope>test</scope>
+    </dependency>
     <dependency>
     	<groupId>org.jgrapht</groupId>
     	<artifactId>jgrapht-core</artifactId>


### PR DESCRIPTION
Apparently junit-jupiter-params was missing in pom configurations, althrough this may not cause problems to Eclipse users, who import this project for the first time, it will certainly be one for IntelliJ users, who depends on maven configuration.

Also, I have set target java version to 8 due to IntelliJ's default version be set to 5 if it failed in find it in pom.xml.