### PR TITLE
Correct visualization of edge set.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,18 @@
   <groupId>TG</groupId>
   <artifactId>GraphTheory-JGraphT</artifactId>
   <version>0.0.1-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
   <packaging>jar</packaging>
 
   <name>GraphTheory-JGraphT</name>
@@ -15,6 +27,12 @@
   </properties>
 
   <dependencies>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.6.2</version>
+        <scope>test</scope>
+    </dependency>
     <dependency>
     	<groupId>org.jgrapht</groupId>
     	<artifactId>jgrapht-core</artifactId>

--- a/src/main/java/util/RelationshipEdge.java
+++ b/src/main/java/util/RelationshipEdge.java
@@ -102,8 +102,8 @@ public class RelationshipEdge extends DefaultEdge {
 		if (o == null) { // analisa se este eh nulo. se for...
 			return ("{" + getSource() + "," + getTarget() + "}"); // retorna uma representacao no formato "{v1,v2}"
 		} else // caso contrario...
-			//return (att.get("label")).toString() + "->{" + getSource() + "," + getTarget() + "}"; // retorna uma representacao no formato "label->{v1,v2}"
-			return o.toString();
+			return (att.get("label")).toString() + "->{" + getSource() + "," + getTarget() + "}"; // retorna uma representacao no formato "label->{v1,v2}"
+			//return o.toString();
 	}
 	
 	public String toStringAtt() {


### PR DESCRIPTION
This allow a correct visualization of labels from the edge set.

I assume this should be set by default for labs' activities, hence it should also be for cloning this repo.